### PR TITLE
feat(HMS-4049): enable ipa-hcc-auto-enrollment.service via preset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ PYTHON := $(shell rpm --eval '%{python3}')
 PYTHON_SITELIB := $(shell $(PYTHON) -c 'from sys import version_info as v; print("/usr/lib/python{}.{}/site-packages".format(v.major, v.minor))')
 # /usr/lib/systemd/system
 UNITDIR:= $(shell rpm --eval '%{_unitdir}')
+# /usr/lib/systemd/system-preset
+PRESETDIR := $(shell rpm --eval '%{_presetdir}')
 # /usr/share/man
 MANDIR:= $(shell rpm --eval '%{_mandir}')
 # /var/lib
@@ -221,6 +223,9 @@ install_client:
 	$(CP_PD) $(srcdir)/install/client/systemd/ipa-hcc-auto-enrollment.service $(DEST)$(UNITDIR)/
 	$(MKDIR_P) $(DEST)$(SYSCONFDIR)/sysconfig
 	$(CP_CONFIG) $(srcdir)/install/client/sysconfig/ipa-hcc-auto-enrollment $(DEST)$(SYSCONFDIR)/sysconfig/
+	# create directory for systemd presets
+	$(MKDIR_P) $(DEST)$(PRESETDIR)
+	$(CP_PD) $(srcdir)/install/client/systemd/80-ipa-hcc-auto-enrollment.preset $(DEST)$(PRESETDIR)/
 
 .PHONY: install_client_prepare
 install_client_prepare:

--- a/install/client/systemd/80-ipa-hcc-auto-enrollment.preset
+++ b/install/client/systemd/80-ipa-hcc-auto-enrollment.preset
@@ -1,0 +1,1 @@
+enable ipa-hcc-auto-enrollment.service

--- a/ipa-hcc.spec.rpkg
+++ b/ipa-hcc.spec.rpkg
@@ -571,6 +571,7 @@ rm -rf %{buildroot}%{python3_sitelib}/__pycache__
 %license COPYING
 %attr(0755,root,root) %{_libexecdir}/ipa-hcc/ipa-hcc-auto-enrollment
 %attr(0644,root,root) %{_unitdir}/ipa-hcc-auto-enrollment.service
+%attr(0644,root,root) %{_presetdir}/80-ipa-hcc-auto-enrollment.preset
 %attr(0644,root,root) %config(noreplace) %{_sysconfdir}/sysconfig/ipa-hcc-auto-enrollment
 %endif
 


### PR DESCRIPTION
Add preset file to enable ipa-hcc-auto-enrollment.service automatically.

This will help avoiding the need to enable the service manually, e.g. in use cases where the ipa-hcc-client is part of a pre-built image.